### PR TITLE
feat: added homepage layout of tablet and close button when sidebar expanded

### DIFF
--- a/index.html
+++ b/index.html
@@ -598,7 +598,10 @@
       <section class="filter-menu menu-invisible">
         <div class="filter-menu-wrapper">
           <div class="filter-menu-title">
-            <h3>篩選功能列</h3>
+            <div class="title-group">
+              <button class="close-menu"><i class="fa-solid fa-xmark"></i></button>
+              <h3>篩選功能列</h3>
+            </div>
             <button>
               <i class="fa-solid fa-eraser"><p>ALL</p></i>
             </button>

--- a/src/components/filter-display/filter-display.scss
+++ b/src/components/filter-display/filter-display.scss
@@ -6,8 +6,8 @@ section.filter-display {
   grid-column-gap: 20px;
   grid-row-gap: 16px;
   font-size: 12px;
-  transition: all 0.3s ease;
   margin-bottom: 16px;
+  transition: all 0.3s ease;
 }
 
 div.pokemon-filter {
@@ -291,9 +291,6 @@ div.species-filter {
 }
 
 div.filter-button-wrapper {
-  width: 82px;
-  height: 82px;
-
   button.filter-button {
     width: 100%;
     height: 100%;
@@ -333,8 +330,6 @@ div.filter-button-wrapper {
 
 div.result-stats {
   position: relative;
-  bottom: -8px;
-  font-size: 16px;
   color: utils.$defaultWhite;
 }
 
@@ -346,7 +341,6 @@ div.pokemon-search {
       height: 32px;
       border: none;
       border-radius: 12px;
-      width: 300px;
       padding-left: 12px;
     }
 

--- a/src/components/filter-display/filter-display.scss
+++ b/src/components/filter-display/filter-display.scss
@@ -406,10 +406,68 @@ div.content-view {
   }
 }
 
-.display-expand {
-  grid-template-columns: 408px calc(100% - 408px - 20px - 82px - 20px) 82px;
+@media screen and (min-width: 1025px) {
+  section.filter-display {
+    div.filter-title {
+      display: flex;
+    }
+  }
+
+  div.filter-button-wrapper {
+    width: 82px;
+    height: 82px;
+  }
+
+  div.result-stats {
+    bottom: -8px;
+    font-size: 16px;
+  }
+
+  div.pokemon-search {
+    input {
+      width: 300px;
+    }
+  }
+
+  .display-expand {
+    grid-template-columns: 408px calc(100% - 408px - 20px - 82px - 20px) 82px;
+  }
+
+  .display-collapse {
+    grid-template-columns: 408px calc(100% - 408px - 20px - 82px - 20px - 344px - 20px) 82px;
+  }
 }
 
-.display-collapse {
-  grid-template-columns: 408px calc(100% - 408px - 20px - 82px - 20px - 344px - 20px) 82px;
+@media screen and (max-width: 1024px) and (min-width: 768px) {
+  section.filter-display {
+    div.filter-title {
+      display: flex;
+    }
+  }
+
+  div.filter-button-wrapper {
+    width: 82px;
+    height: 82px;
+  }
+
+  div.result-stats {
+    bottom: -8px;
+    font-size: 16px;
+  }
+
+  div.pokemon-search {
+    input {
+      width: 100%;
+    }
+  }
+
+  .display-expand {
+    grid-template-columns: 360px calc(100% - 360px - 20px - 82px - 20px) 82px;
+  }
+  // TODO: here for .result-collapse and ensure that url('./src/component/filter-display/index.js') does not affect screen devices with a max-width of 1024px or less."
+
+  .display-collapse {
+    grid-template-columns: 360px calc(100% - 360px - 20px - 82px - 20px) 82px;
+  }
+  // TODO: here for .result-collapse and ensure that url('./src/component/filter-display/index.js') does not affect screen devices with a max-width of 1024px or less."
 }

--- a/src/components/filter-display/index.js
+++ b/src/components/filter-display/index.js
@@ -4,6 +4,7 @@ const filterArrowIcon = filterMenuToggleButton.querySelector('.fa-angle-left');
 const filterMenu = document.querySelector('.filter-menu');
 const filterResultHead = document.querySelector('.filter-result-head');
 const filterResultBody = document.querySelector('.filter-result-body');
+const filterMenuCloseButton = document.querySelector('.close-menu');
 
 function toggleFilterMenu() {
   const isExpanded = filterDisplay.classList.contains('display-expand');
@@ -24,4 +25,23 @@ function toggleFilterMenu() {
   filterResultBody.classList.toggle('result-collapse', isExpanded);
 }
 
+function closeFilterMenu() {
+  filterDisplay.classList.remove('display-collapse');
+  filterDisplay.classList.add('display-expand');
+
+  filterArrowIcon.classList.remove('fa-angle-right');
+  filterArrowIcon.classList.add('fa-angle-left');
+
+  filterMenu.classList.remove('menu-visible');
+  filterMenu.classList.add('menu-invisible');
+
+  filterResultHead.classList.remove('result-collapse');
+  filterResultHead.classList.add('result-expand');
+
+  filterResultBody.classList.remove('result-collapse');
+  filterResultBody.classList.add('result-expand');
+}
+
 filterMenuToggleButton.addEventListener('click', toggleFilterMenu);
+filterMenuCloseButton.addEventListener('click', closeFilterMenu);
+//TODO: At resolutions of 1024px or below, pressing the `filterMenuToggleButton` will display an overlay. Pressing the `filterMenuCloseButton` will make the overlay disappear.

--- a/src/components/filter-menu/filter-menu.scss
+++ b/src/components/filter-menu/filter-menu.scss
@@ -1,15 +1,10 @@
 @use '../../utils/utils.scss';
 
 section.filter-menu {
-  position: absolute;
-  top: 0;
-  margin-top: 20px;
   transition: all 0.3s ease;
 
   div.filter-menu-wrapper {
     position: relative;
-    width: 344px;
-    height: calc(100vh - 40px);
     background: utils.$defaultGrey700;
     border-radius: 12px;
 
@@ -17,10 +12,10 @@ section.filter-menu {
       display: flex;
       justify-content: space-between;
       align-items: center;
-      padding: 16px 32px;
 
       button {
-        padding: 4px 8px;
+        width: 32px;
+        height: 40px;
         border-radius: 6px;
 
         i {
@@ -47,8 +42,6 @@ section.filter-menu {
       width: 100%;
       bottom: 0;
       background: utils.$defaultWhite;
-      height: calc(100vh - 105px);
-      border-radius: 12px;
       overflow-y: scroll;
     }
   }

--- a/src/components/filter-menu/filter-menu.scss
+++ b/src/components/filter-menu/filter-menu.scss
@@ -149,6 +149,12 @@ div.filter-wrapper {
 
       div.filter-menu-title {
         padding: 16px 32px;
+
+        div.title-group {
+          button.close-menu {
+            display: none;
+          }
+        }
       }
 
       div.scroll-wrapper {
@@ -181,6 +187,17 @@ div.filter-wrapper {
 
       div.filter-menu-title {
         padding: 16px 32px 16px 8px;
+
+        div.title-group {
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          gap: 8px;
+
+          button.close-menu {
+            display: block;
+          }
+        }
       }
 
       div.scroll-wrapper {

--- a/src/components/filter-menu/filter-menu.scss
+++ b/src/components/filter-menu/filter-menu.scss
@@ -137,43 +137,66 @@ div.filter-wrapper {
   right: 0;
   opacity: 1;
 }
+@media screen and (min-width: 1025px) {
+  section.filter-menu {
+    position: absolute;
+    top: 0;
+    margin-top: 20px;
 
-div.types-filter {
-  &:after {
-    background: utils.$optionColorRed;
+    div.filter-menu-wrapper {
+      width: 344px;
+      height: calc(100vh - 40px);
+
+      div.filter-menu-title {
+        padding: 16px 32px;
+      }
+
+      div.scroll-wrapper {
+        height: calc(100vh - 105px);
+        border-radius: 12px;
+      }
+    }
   }
 
-  h4 {
-    color: utils.$optionColorRed;
+  .menu-invisible {
+    right: -344px;
+    opacity: 0;
+  }
+
+  .menu-visible {
+    right: 0;
+    opacity: 1;
   }
 }
 
-div.abilities-filter {
-  &:after {
-    background: utils.$optionColorOrange;
+@media screen and (max-width: 1024px) and (min-width: 768px) {
+  section.filter-menu {
+    position: absolute;
+    top: 0;
+    margin-top: 20px;
+
+    div.filter-menu-wrapper {
+      width: 344px;
+      height: calc(100vh - 40px);
+
+      div.filter-menu-title {
+        padding: 16px 32px 16px 8px;
+      }
+
+      div.scroll-wrapper {
+        height: calc(100vh - 105px);
+        border-radius: 12px;
+      }
+    }
   }
 
-  h4 {
-    color: utils.$optionColorOrange;
-  }
-}
-
-div.stats-filter {
-  &:after {
-    background: utils.$optionColorGreen;
+  .menu-invisible {
+    right: -344px;
+    opacity: 0;
   }
 
-  h4 {
-    color: utils.$optionColorGreen;
-  }
-}
-
-div.moves-filter {
-  &:after {
-    background: utils.$optionColorPurple;
-  }
-
-  h4 {
-    color: utils.$optionColorPurple;
+  .menu-visible {
+    right: 0;
+    opacity: 1;
   }
 }

--- a/src/components/filter-menu/filter-menu.scss
+++ b/src/components/filter-menu/filter-menu.scss
@@ -121,6 +121,46 @@ div.filter-wrapper {
   }
 }
 
+div.types-filter {
+  &:after {
+    background: utils.$optionColorRed;
+  }
+
+  h4 {
+    color: utils.$optionColorRed;
+  }
+}
+
+div.abilities-filter {
+  &:after {
+    background: utils.$optionColorOrange;
+  }
+
+  h4 {
+    color: utils.$optionColorOrange;
+  }
+}
+
+div.stats-filter {
+  &:after {
+    background: utils.$optionColorGreen;
+  }
+
+  h4 {
+    color: utils.$optionColorGreen;
+  }
+}
+
+div.moves-filter {
+  &:after {
+    background: utils.$optionColorPurple;
+  }
+
+  h4 {
+    color: utils.$optionColorPurple;
+  }
+}
+
 .menu-invisible {
   right: -344px;
   opacity: 0;

--- a/src/components/filter-results/filter-results.scss
+++ b/src/components/filter-results/filter-results.scss
@@ -15,14 +15,11 @@ div.result-scrollable-container {
 section.filter-result-head {
   position: relative;
   display: grid;
-  margin-bottom: 4px;
   transition: all 0.3s ease;
 
   div.result-head-container {
     display: flex;
     flex-direction: row;
-    gap: 8px;
-    padding: 12px;
     background: utils.$defaultGrey100;
   }
 
@@ -32,54 +29,26 @@ section.filter-result-head {
     box-shadow: 10px 0 5px -5px rgba(0, 0, 0, 0.15);
     z-index: 1;
     display: grid;
-    grid-template-columns: 80px 308px;
-    grid-template-rows: 86px;
-    gap: 8px;
 
     div.result-title {
       display: flex;
       flex-direction: column;
-      gap: 8px;
-      width: 100%;
 
       div.table-title {
         display: flex;
         justify-content: center;
         align-items: center;
-        padding: 8px;
-        border-radius: 4px;
-        font-size: 16px;
         background: utils.$defaultWhite;
-
-        &:first-child {
-          height: 86px;
-        }
       }
 
       div.subtitle-group {
         display: flex;
-        gap: 8px;
         justify-content: flex-start;
         align-items: center;
 
         div.subtitle {
-          padding: 8px;
-          border-radius: 4px;
-          font-size: 16px;
           background: utils.$defaultWhite;
           text-align: center;
-
-          &:first-child {
-            width: 80px;
-          }
-
-          &:nth-child(2) {
-            width: 128px;
-          }
-
-          &:last-child {
-            width: 84px;
-          }
         }
       }
     }
@@ -89,31 +58,21 @@ section.filter-result-head {
     div.result-title {
       display: flex;
       flex-direction: column;
-      gap: 8px;
 
       div.table-title {
         display: flex;
         justify-content: center;
         align-items: center;
-        min-width: 90px;
-        width: auto;
-        padding: 8px;
-        border-radius: 4px;
-        font-size: 16px;
         background: utils.$defaultWhite;
       }
 
       div.subtitle-group {
         display: flex;
-        gap: 8px;
         justify-content: flex-start;
         align-items: center;
 
         div.subtitle {
           position: relative;
-          padding: 8px;
-          border-radius: 4px;
-          font-size: 16px;
           background: utils.$defaultWhite;
           text-align: center;
           flex-grow: 1;
@@ -126,22 +85,12 @@ section.filter-result-head {
         background: utils.$optionColorRed;
         color: utils.$defaultWhite;
       }
-
-      div.subtitle {
-        min-width: 100px;
-        width: auto;
-      }
     }
 
     div.pokemon-abilities {
       div.table-title {
         background: utils.$optionColorOrange;
         color: utils.$defaultWhite;
-      }
-
-      div.subtitle {
-        min-width: 120px;
-        width: auto;
       }
     }
 
@@ -150,22 +99,12 @@ section.filter-result-head {
         background: utils.$optionColorGreen;
         color: utils.$defaultWhite;
       }
-
-      div.subtitle {
-        min-width: 64px;
-        width: auto;
-      }
     }
 
     div.pokemon-moves {
       div.table-title {
         background: utils.$optionColorPurple;
         color: utils.$defaultWhite;
-      }
-
-      div.subtitle {
-        min-width: 90px;
-        width: auto;
       }
     }
   }
@@ -174,25 +113,16 @@ section.filter-result-head {
 section.filter-result-body {
   position: relative;
   display: grid;
-  margin-bottom: 20px;
-  height: calc(100vh - 94px - 148px - 114px - 20px);
   transition: all 0.3s ease;
 
   div.result-body-container {
     display: flex;
     flex-direction: column;
-    gap: 8px;
-    padding: 12px;
-    width: auto;
-    height: auto;
     background: utils.$defaultGrey100;
     overflow: scroll;
   }
 
   div.result {
-    width: 100%;
-    height: 39px;
-    border-radius: 4px;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -212,8 +142,6 @@ section.filter-result-body {
     div.result-identify {
       position: relative;
       display: grid;
-      gap: 8px;
-      grid-template-columns: 80px 80px 128px 84px;
 
       div.result-pokemon-picture {
         overflow: hidden;
@@ -221,8 +149,6 @@ section.filter-result-body {
         img {
           position: relative;
           top: 0;
-          width: 40px;
-          height: auto;
         }
       }
     }
@@ -231,9 +157,6 @@ section.filter-result-body {
   div.result-species {
     position: relative;
     display: flex;
-    gap: 8px;
-    padding-right: 12px;
-    flex-direction: row;
     justify-content: flex-start;
     align-items: center;
 
@@ -242,6 +165,10 @@ section.filter-result-body {
       justify-content: flex-start;
       align-items: center;
       width: auto;
+    }
+  }
+}
+
 @media screen and (min-width: 1025px) {
   section.filter-result-head {
     margin-bottom: 4px;

--- a/src/components/filter-results/filter-results.scss
+++ b/src/components/filter-results/filter-results.scss
@@ -242,55 +242,407 @@ section.filter-result-body {
       justify-content: flex-start;
       align-items: center;
       width: auto;
+@media screen and (min-width: 1025px) {
+  section.filter-result-head {
+    margin-bottom: 4px;
+
+    div.result-head-container {
       gap: 8px;
+      padding: 12px;
     }
 
-    div.pokemon-types {
-      div.result-type-double {
-        width: 100px;
-      }
+    div.result-head-fixed-container {
+      grid-template-columns: 80px 308px;
+      grid-template-rows: 86px;
+      gap: 8px;
 
-      div.result-type-single {
-        width: 208px;
+      div.result-title {
+        gap: 8px;
+        width: 100%;
+
+        div.table-title {
+          padding: 8px;
+          border-radius: 4px;
+          font-size: 16px;
+
+          &:first-child {
+            height: 86px;
+          }
+        }
+
+        div.subtitle-group {
+          gap: 8px;
+
+          div.subtitle {
+            padding: 8px;
+            border-radius: 4px;
+            font-size: 16px;
+
+            &:first-child {
+              width: 80px;
+            }
+
+            &:nth-child(2) {
+              width: 128px;
+            }
+
+            &:last-child {
+              width: 84px;
+            }
+          }
+        }
       }
     }
 
-    div.pokemon-abilities {
-      div.result-ability-double {
-        width: 120px;
+    div.result-scrollable-container {
+      div.result-title {
+        gap: 8px;
+
+        div.table-title {
+          min-width: 90px;
+          width: auto;
+          padding: 8px;
+          border-radius: 4px;
+          font-size: 16px;
+        }
+
+        div.subtitle-group {
+          gap: 8px;
+
+          div.subtitle {
+            padding: 8px;
+            border-radius: 4px;
+            font-size: 16px;
+          }
+        }
       }
 
-      div.result-ability-single {
-        width: 248px;
+      div.pokemon-types {
+        div.subtitle {
+          min-width: 100px;
+          width: auto;
+        }
       }
 
-      div.result-ability-hidden {
-        width: 120px;
+      div.pokemon-abilities {
+        div.subtitle {
+          min-width: 120px;
+          width: auto;
+        }
       }
-    }
 
-    div.pokemon-stats {
-      div.result-stat {
-        width: 64px;
+      div.pokemon-stats {
+        div.subtitle {
+          min-width: 64px;
+          width: auto;
+        }
       }
-    }
 
-    div.pokemon-move {
-      min-width: 90px;
-      width: auto;
-
-      div.result-move-name {
-        min-width: 90px;
-        width: auto;
+      div.pokemon-moves {
+        div.subtitle {
+          min-width: 90px;
+          width: auto;
+        }
       }
     }
   }
+
+  section.filter-result-body {
+    margin-bottom: 20px;
+    height: calc(100vh - 94px - 148px - 114px - 20px);
+
+    div.result-body-container {
+      gap: 8px;
+      padding: 12px;
+    }
+
+    div.result {
+      width: 100%;
+      height: 39px;
+      border-radius: 4px;
+    }
+
+    div.result-body-scrollY-container {
+      div.result-identify {
+        gap: 8px;
+        grid-template-columns: 80px 80px 128px 84px;
+
+        div.result-pokemon-picture {
+          img {
+            width: 40px;
+            height: auto;
+          }
+        }
+      }
+    }
+
+    div.result-species {
+      position: relative;
+      display: flex;
+      gap: 8px;
+      padding-right: 12px;
+      flex-direction: row;
+      justify-content: flex-start;
+      align-items: center;
+
+      div.result-species-group {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        width: auto;
+        gap: 8px;
+      }
+
+      div.pokemon-types {
+        div.result-type-double {
+          width: 100px;
+        }
+
+        div.result-type-single {
+          width: 208px;
+        }
+      }
+
+      div.pokemon-abilities {
+        div.result-ability-double {
+          width: 120px;
+        }
+
+        div.result-ability-single {
+          width: 248px;
+        }
+
+        div.result-ability-hidden {
+          width: 120px;
+        }
+      }
+
+      div.pokemon-stats {
+        div.result-stat {
+          width: 64px;
+        }
+      }
+
+      div.pokemon-move {
+        min-width: 90px;
+        width: auto;
+
+        div.result-move-name {
+          min-width: 90px;
+          width: auto;
+        }
+      }
+    }
+  }
+
+  .result-expand {
+    grid-template-columns: 420px calc(100% - 400px - 20px);
+  }
+
+  .result-collapse {
+    grid-template-columns: 420px calc(100% - 408px - 344px - 20px - 12px);
+  }
 }
 
-.result-expand {
-  grid-template-columns: 420px calc(100% - 400px - 20px);
-}
+@media screen and (max-width: 1024px) and (min-width: 768px) {
+  section.filter-result-head {
+    margin-bottom: 4px;
 
-.result-collapse {
-  grid-template-columns: 420px calc(100% - 408px - 344px - 20px - 12px);
+    div.result-head-container {
+      gap: 8px;
+      padding: 12px;
+    }
+
+    div.result-head-fixed-container {
+      grid-template-columns: 64px 284px;
+      grid-template-rows: 86px;
+      gap: 8px;
+
+      div.result-title {
+        gap: 8px;
+        width: 100%;
+
+        div.table-title {
+          padding: 8px;
+          border-radius: 4px;
+          font-size: 16px;
+
+          &:first-child {
+            height: 86px;
+          }
+        }
+
+        div.subtitle-group {
+          gap: 8px;
+
+          div.subtitle {
+            padding: 8px;
+            border-radius: 4px;
+            font-size: 16px;
+
+            &:first-child {
+              width: 64px;
+            }
+
+            &:nth-child(2) {
+              width: 120px;
+            }
+
+            &:last-child {
+              width: 84px;
+            }
+          }
+        }
+      }
+    }
+
+    div.result-scrollable-container {
+      div.result-title {
+        gap: 8px;
+
+        div.table-title {
+          min-width: 90px;
+          width: auto;
+          padding: 8px;
+          border-radius: 4px;
+          font-size: 16px;
+        }
+
+        div.subtitle-group {
+          gap: 8px;
+
+          div.subtitle {
+            padding: 8px;
+            border-radius: 4px;
+            font-size: 16px;
+          }
+        }
+      }
+
+      div.pokemon-types {
+        div.subtitle {
+          min-width: 100px;
+          width: auto;
+        }
+      }
+
+      div.pokemon-abilities {
+        div.subtitle {
+          min-width: 120px;
+          width: auto;
+        }
+      }
+
+      div.pokemon-stats {
+        div.subtitle {
+          min-width: 64px;
+          width: auto;
+        }
+      }
+
+      div.pokemon-moves {
+        div.subtitle {
+          min-width: 90px;
+          width: auto;
+        }
+      }
+    }
+  }
+
+  section.filter-result-body {
+    margin-bottom: 20px;
+    height: calc(100vh - 94px - 148px - 114px - 20px);
+
+    div.result-body-container {
+      gap: 8px;
+      padding: 12px;
+    }
+
+    div.result {
+      width: 100%;
+      height: 39px;
+      border-radius: 4px;
+    }
+
+    div.result-body-scrollY-container {
+      div.result-identify {
+        gap: 8px;
+        grid-template-columns: 64px 64px 120px 84px;
+
+        div.result-pokemon-picture {
+          img {
+            width: 40px;
+            height: auto;
+          }
+        }
+      }
+    }
+
+    div.result-species {
+      position: relative;
+      display: flex;
+      gap: 8px;
+      padding-right: 12px;
+      flex-direction: row;
+      justify-content: flex-start;
+      align-items: center;
+
+      div.result-species-group {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+        width: auto;
+        gap: 8px;
+      }
+
+      div.pokemon-types {
+        div.result-type-double {
+          width: 100px;
+        }
+
+        div.result-type-single {
+          width: 208px;
+        }
+      }
+
+      div.pokemon-abilities {
+        div.result-ability-double {
+          width: 120px;
+        }
+
+        div.result-ability-single {
+          width: 248px;
+        }
+
+        div.result-ability-hidden {
+          width: 120px;
+        }
+      }
+
+      div.pokemon-stats {
+        div.result-stat {
+          width: 64px;
+        }
+      }
+
+      div.pokemon-move {
+        min-width: 90px;
+        width: auto;
+
+        div.result-move-name {
+          min-width: 90px;
+          width: auto;
+        }
+      }
+    }
+  }
+
+  .result-expand {
+    grid-template-columns: 380px calc(100% - 360px - 20px);
+  }
+
+  .result-collapse {
+    grid-template-columns: 380px calc(100% - 360px - 20px);
+  }
+  // TODO: here for .result-collapse and ensure that url('./src/component/filter-display/index.js') does not affect screen devices with a max-width of 1024px or less."
 }


### PR DESCRIPTION
- Added desktop homepage layout featuring filter-display, filter-results, and filter-menu.
- Added a close button in the top-left corner when expanding the filter-menu sidebar on tablet-sized devices.

subticket:
[PF-3](https://stanleyhaw94.atlassian.net/browse/PF-3?atlOrigin=eyJpIjoiNWIwM2U3MThlMTQwNDMwYjkwNTgyMjQwMzMwOWViMWYiLCJwIjoiaiJ9)